### PR TITLE
Fix the deep_prior build and seed

### DIFF
--- a/changelog/49.fix.md
+++ b/changelog/49.fix.md
@@ -1,0 +1,12 @@
+Two defects of the `deep_prior` method are fixed.
+
+`B` and `num_samples` could not be changed. The coupling networks were built
+again on every call, and Keras stores the batch dimensions of the first
+build. A fit with `B=64` raised `Sequential model has already been configured
+to use input shape (128, 200, 2)`. The network is now built once.
+
+A normalizing flow could not be rebuilt from its seed. The permutation layers
+draw from the global generator of `numpy`, which `tf.random.set_seed` does
+not control, so two networks built from the same seed permuted differently.
+The construction now runs with a seeded generator, and restores the state of
+the caller.

--- a/src/elicito/methods.py
+++ b/src/elicito/methods.py
@@ -2,8 +2,11 @@
 Strategy objects for the prior-learning methods
 """
 
+import contextlib
+from collections.abc import Iterator
 from typing import Any, Protocol
 
+import numpy as np
 import tensorflow as tf
 
 import elicito as el
@@ -17,6 +20,37 @@ from elicito.types import (
     Target,
     Trainer,
 )
+
+
+@contextlib.contextmanager
+def numpy_seed(seed: int) -> Iterator[None]:
+    """
+    Seed the numpy global generator for the duration of the block
+
+    A network can draw from the numpy global generator while it is built.
+    `elicito.networks.Permutation` does, and `tf.random.set_seed` does not
+    control that generator. Two networks built from the same seed then
+    permute differently, and a fitted network cannot be rebuilt from its
+    stored weights.
+
+    The generator of the caller is restored on exit.
+
+    Parameters
+    ----------
+    seed
+        Seed of the current workflow run.
+
+    Yields
+    ------
+    :
+        None. The block runs with the seeded generator.
+    """
+    state = np.random.get_state()  # noqa: NPY002
+    np.random.seed(seed)  # noqa: NPY002
+    try:
+        yield
+    finally:
+        np.random.set_state(state)  # noqa: NPY002
 
 
 def _constraints(parameters: list[Parameter]) -> dict[str, Any]:
@@ -405,7 +439,10 @@ class DeepPrior:
         if network is not None:
             INN = network["inference_network"]
 
-            invertible_neural_network = INN(**network["network_specs"])  # type: ignore [call-arg]
+            # The permutation layers draw from the numpy global generator,
+            # see `numpy_seed`.
+            with numpy_seed(seed):
+                invertible_neural_network = INN(**network["network_specs"])  # type: ignore [call-arg]
 
             # save initialized priors
             init_prior = invertible_neural_network

--- a/src/elicito/networks.py
+++ b/src/elicito/networks.py
@@ -262,7 +262,12 @@ class DenseCouplingNet(tf.keras.Model):  # type: ignore
         out :
             residual output
         """
-        self.fc.build(input_shape=target.shape)
+        # Keras stores the full shape, batch dimensions included, and
+        # refuses a second build with a different one. The dense layers
+        # only read the last axis, so one build is enough. Without the
+        # guard, B and num_samples cannot change after the first call.
+        if not self.fc.built:
+            self.fc.build(input_shape=target.shape)
         # Handle case no condition
         if condition is None:
             if self.residual_output is not None:

--- a/src/elicito/networks.py
+++ b/src/elicito/networks.py
@@ -262,10 +262,6 @@ class DenseCouplingNet(tf.keras.Model):  # type: ignore
         out :
             residual output
         """
-        # Keras stores the full shape, batch dimensions included, and
-        # refuses a second build with a different one. The dense layers
-        # only read the last axis, so one build is enough. Without the
-        # guard, B and num_samples cannot change after the first call.
         if not self.fc.built:
             self.fc.build(input_shape=target.shape)
         # Handle case no condition

--- a/tests/unit/test_methods.py
+++ b/tests/unit/test_methods.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from elicito.methods import numpy_seed
+from elicito.networks import InvertibleNetwork
+
+
+def test_two_flows_from_one_seed_permute_alike():
+    """The fixed permutations become a function of the seed."""
+
+    def build():
+        with numpy_seed(123):
+            return InvertibleNetwork(num_params=3, num_coupling_layers=2)
+
+    first, second = build(), build()
+    for l1, l2 in zip(first.coupling_layers, second.coupling_layers):
+        assert np.array_equal(
+            l1.permutation.permutation.numpy(), l2.permutation.permutation.numpy()
+        )
+
+
+def test_numpy_seed_restores_the_generator():
+    """The generator of the caller survives the block."""
+    np.random.seed(7)  # noqa: NPY002
+    expected = np.random.permutation(5)  # noqa: NPY002
+    np.random.seed(7)  # noqa: NPY002
+    with numpy_seed(123):
+        np.random.permutation(5)  # noqa: NPY002
+    assert np.array_equal(np.random.permutation(5), expected)  # noqa: NPY002

--- a/tests/unit/test_networks.py
+++ b/tests/unit/test_networks.py
@@ -192,3 +192,11 @@ def test_invertible_network(  # noqa: PLR0912
         assert ldj.shape[0] == inp.shape[0]
     else:
         assert ldj.shape[0] == inp.shape[0] and ldj.shape[1] == inp.shape[1]
+
+
+def test_network_accepts_a_second_batch_shape():
+    """One build, so B and num_samples can change after the first call."""
+    network = InvertibleNetwork(num_params=2, num_coupling_layers=2)
+    network(np.random.normal(size=(128, 200, 2)).astype(np.float32), None)  # noqa: NPY002
+    z, _ = network(np.random.normal(size=(64, 200, 2)).astype(np.float32), None)  # noqa: NPY002
+    assert z.shape == (64, 200, 2)


### PR DESCRIPTION
## Description

Two bugs in the `deep_prior` method.

**`B` and `num_samples` could not be changed.** 

`DenseCouplingNet.call` built the dense layers on every call. Keras keeps the full shape of the first build,
batch dimensions included, and refuses a second one. A fit with `B=64` after a fit with `B=128` raised `Sequential model has already been configured to use input shape (128, 200, 2)`. The dense layers read the last axis only, so the
build now runs once.

**A flow could not be rebuilt from its seed.** 

The permutation layers draw from the global generator of `numpy`. `tf.random.set_seed` does not control that
generator, so two flows built from the same seed permuted differently. The new `numpy_seed` context manager seeds the generator around the construction, and restores the state of the caller.

## Tests

- `test_network_accepts_a_second_batch_shape`: one flow, two batch shapes.
- `test_two_flows_from_one_seed_permute_alike`:  one seed, equal permutations.
- `test_numpy_seed_restores_the_generator`: the caller keeps its state.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- ~[ ] Documentation added (where applicable)~
- [x] Changelog item added to `changelog/`
