### PR TITLE
Fix the joint prior plot

### DIFF
--- a/changelog/50.fix.md
+++ b/changelog/50.fix.md
@@ -1,0 +1,16 @@
+`el.plots.prior_joint` no longer raises `OverflowError` for a collapsed
+parameter.
+
+A kernel density needs at least three distinct values. A parameter whose draws
+take only two, such as a truncated prior that has collapsed onto its bounds,
+made the bandwidth infinite inside `arviz_stats`. Such a panel now shows one
+line per value, and a warning names the parameter.
+
+A density that fails for any other reason now also leaves its panel empty, with
+a warning that reports the range and the standard deviation of the draws. One
+parameter no longer costs the whole figure. The draws are passed as float64,
+so a wide sample no longer overflows the variance.
+
+Two other defects of the same plot are fixed. The off-diagonal panels were
+transposed, so a column did not share its x-axis with the density on its
+diagonal. A model with one parameter could not be plotted at all.

--- a/changelog/51.feature.md
+++ b/changelog/51.feature.md
@@ -1,0 +1,1 @@
+Select a subset of the model parameters in `el.plots.prior_marginals()` and `el.plots.prior_joint()` with the new `params` argument.

--- a/src/elicito/plots.py
+++ b/src/elicito/plots.py
@@ -366,10 +366,46 @@ def hyperparameter(
     return fig, axes
 
 
+def _select_params(name_params: list[str], params: list[str] | None) -> list[str]:
+    """
+    Keep the requested model parameters, in the order of the request
+
+    Parameters
+    ----------
+    name_params
+        names of all model parameters, in the order of the prior samples.
+
+    params
+        names of the requested parameters. If None, all parameters are kept.
+
+    Returns
+    -------
+    :
+        names of the parameters to plot.
+
+    Raises
+    ------
+    ValueError
+        A name in 'params' is not a model parameter.
+
+    """
+    if params is None:
+        return name_params
+
+    unknown = [p for p in params if p not in name_params]
+    if unknown:
+        raise ValueError(
+            f"Unknown parameter(s) {unknown} in 'params'."
+            + f" Available parameters are {name_params}."
+        )
+    return list(params)
+
+
 def prior_joint(
     eliobj: Any,
     idx: int | list[int] | None = None,
     titles: list[str] | None = None,
+    params: list[str] | None = None,
     **kwargs: dict[Any, Any],
 ) -> tuple["matplotlib.figure.Figure", list["matplotlib.axes.Axes"]]:
     """
@@ -391,6 +427,9 @@ def prior_joint(
     titles : list of str, optional
         Labels for the main diagonal. If None, the names of the hyperparameters
         will be used. The length of titles should match the number of hyperparameters.
+    params : list of str, optional
+        names of the model parameters to plot, in the order of the rows and
+        columns. If None, all model parameters are plotted.
     **kwargs : any, optional
         additional keyword arguments that can be passed to specify
         `plt.subplots() <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.subplots.html>`_
@@ -411,6 +450,8 @@ def prior_joint(
         constraint type.
 
         The value for 'idx' is larger than the number of parallelizations.
+
+        A name in 'params' is not a model parameter.
 
     AttributeError
         Can't find 'prior' in 'eliobj.results'
@@ -450,7 +491,7 @@ def prior_joint(
         )
     cmap = mpl.colormaps["turbo"]
     # get parameter names
-    name_params = list(eliobj.results.prior.data_vars)
+    name_params = _select_params(list(eliobj.results.prior.data_vars), params)
     n_params = len(name_params)
     _, _, titles = _get_names_titles(name_params, titles)
 
@@ -464,7 +505,7 @@ def prior_joint(
         # reshape samples by merging batches and number of samples
         priors = (
             eliobj.results.prior.sel(replication=k)
-            .to_dataset()
+            .to_dataset()[name_params]
             .to_array()
             .stack(stacked=("batch", "draw"))
             .values
@@ -493,7 +534,11 @@ def prior_joint(
 
 
 def prior_marginals(
-    eliobj: Any, cols: int = 4, titles: list[str] | None = None, **kwargs: Any
+    eliobj: Any,
+    cols: int = 4,
+    titles: list[str] | None = None,
+    params: list[str] | None = None,
+    **kwargs: Any,
 ) -> tuple["matplotlib.figure.Figure", np.ndarray[Any, Any]]:
     """
     Plot the convergence of each hyperparameter across epochs.
@@ -508,6 +553,9 @@ def prior_marginals(
     titles : list of str, optional
         titles for each subplot. If None, the names of the hyperparameters
         will be used. The length of titles should match the number of hyperparameters.
+    params : list of str, optional
+        names of the model parameters to plot, in the order of the subplots.
+        If None, all model parameters are plotted.
     **kwargs : any, optional
         additional keyword arguments that can be passed to specify
         `plt.subplots() <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.subplots.html>`_
@@ -525,6 +573,9 @@ def prior_marginals(
     ------
     AttributeError
         Can't find 'prior' in 'eliobj.results'
+
+    ValueError
+        A name in 'params' is not a model parameter.
     """
     eliobj_res, parallel, n_reps = _check_parallel(eliobj)
     # check chains that yield NaN
@@ -532,10 +583,10 @@ def prior_marginals(
         _, success, _ = _check_NaN(eliobj, n_reps)
     else:
         success = [0]
+    # get parameter names, and keep only the requested ones
+    name_params = _select_params(list(eliobj.results.prior.data_vars), params)
     # get shape of prior samples
-    n_par = len(list(eliobj.results.prior.data_vars))
-    # get parameter names
-    name_params = list(eliobj.results.prior.data_vars)
+    n_par = len(name_params)
     _, _, titles = _get_names_titles(name_params, titles)
     # prepare plot axes
     (cols, rows, _) = _prep_subplots(eliobj, cols, n_par, bounderies=False)
@@ -557,7 +608,7 @@ def prior_marginals(
         for i in success:
             priors = (
                 eliobj.results.prior.sel(replication=i)
-                .to_dataset()
+                .to_dataset()[name_params]
                 .stack(combined=("batch", "draw"))
                 .to_array()
                 .values

--- a/src/elicito/plots.py
+++ b/src/elicito/plots.py
@@ -19,6 +19,82 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
 
+def _plot_density(ax: Any, values: Any, name: str, **line_kwargs: Any) -> None:
+    """
+    Draw the density of one parameter, or one line per value if it collapsed
+
+    A kernel density needs at least three distinct values. Two values make the
+    bandwidth infinite, and ``array_stats.kde`` then raises an
+    ``OverflowError``. A collapsed prior is a result worth seeing, so the panel
+    shows one line per value instead of a density, and the figure is drawn.
+
+    A density can fail for other reasons as well. A draw far outside the range
+    of the others, for example, gives a bin width of zero and the same infinite
+    bandwidth. The panel is then left empty, with a warning. One parameter must
+    not cost the whole figure: the other panels show where the prior went.
+
+    Parameters
+    ----------
+    ax
+        Axes to draw on.
+
+    values
+        Draws of one parameter.
+
+    name
+        Name of the parameter, used in the warning.
+
+    **line_kwargs
+        Passed to the plot, e.g. ``color`` and ``lw``.
+
+    Raises
+    ------
+    MissingOptionalDependencyError
+        ``arviz_stats`` is required for the density.
+
+    """
+    try:
+        from arviz_stats.base import array_stats  # type: ignore
+    except ImportError as exc:
+        raise MissingOptionalDependencyError(
+            "plotting", requirement="arviz_stats"
+        ) from exc
+
+    draws = np.ravel(np.asarray(values))
+    finite = draws[np.isfinite(draws)]
+    if len(finite) < len(draws):
+        logger.warning(
+            f"'{name}': {len(draws) - len(finite)} of {len(draws)} draws are"
+            " not finite. They are left out of the density."
+        )
+
+    distinct = np.unique(finite)
+    if len(distinct) < 3:  # noqa: PLR2004
+        logger.warning(
+            f"'{name}' has {len(distinct)} distinct value(s) in {len(finite)}"
+            " finite draws, so it has no density. The prior of this parameter"
+            " has collapsed. The panel shows one line per value."
+        )
+        for value in distinct:
+            ax.axvline(float(value), **line_kwargs)
+        return
+
+    # float64 keeps the variance of a wide sample finite. In float32 it
+    # overflows above 1e19, and the bandwidth is then not a number.
+    try:
+        grid, pdf, _ = array_stats.kde(finite.astype(np.float64))  # type: ignore
+    except (OverflowError, ValueError, ZeroDivisionError, FloatingPointError) as exc:
+        logger.warning(
+            f"'{name}' has no density: {type(exc).__name__}: {exc}. The panel"
+            f" is empty. The {len(distinct)} distinct draws lie between"
+            f" {float(distinct[0]):.4g} and {float(distinct[-1]):.4g}, with a"
+            f" standard deviation of {float(np.std(finite)):.4g}."
+        )
+        return
+
+    ax.plot(grid, pdf, **line_kwargs)
+
+
 def initialization(
     eliobj: Any, cols: int = 4, titles: list[str] | None = None, **kwargs: Any
 ) -> tuple["matplotlib.figure.Figure", np.ndarray[Any, Any]]:
@@ -348,13 +424,6 @@ def prior_joint(
             "plotting", requirement="matplotlib"
         ) from exc
 
-    try:
-        from arviz_stats.base import array_stats  # type: ignore
-    except ImportError as exc:
-        raise MissingOptionalDependencyError(
-            "plotting", requirement="arviz_stats"
-        ) from exc
-
     if idx is None:
         idx = [0]
     if type(idx) is not list:
@@ -385,20 +454,25 @@ def prior_joint(
     n_params = len(name_params)
     _, _, titles = _get_names_titles(name_params, titles)
 
-    fig, axs = plt.subplots(n_params, n_params, constrained_layout=True, **kwargs)  # type: ignore
+    # `squeeze=False` keeps the two indices of `axs` for a model with one
+    # parameter
+    fig, axs = plt.subplots(  # type: ignore
+        n_params, n_params, constrained_layout=True, squeeze=False, **kwargs
+    )
     colors = cmap(np.linspace(0, 1, len(idx)))
     for c, k in enumerate(idx):
+        # reshape samples by merging batches and number of samples
+        priors = (
+            eliobj.results.prior.sel(replication=k)
+            .to_dataset()
+            .to_array()
+            .stack(stacked=("batch", "draw"))
+            .values
+        )
         for i in range(n_params):
-            # reshape samples by merging batches and number of samples
-            priors = (
-                eliobj.results.prior.sel(replication=k)
-                .to_dataset()
-                .to_array()
-                .stack(stacked=("batch", "draw"))
-                .values
+            _plot_density(
+                axs[i, i], priors[i, :], name_params[i], color=colors[c], lw=2
             )
-            grid, pdf, _ = array_stats.kde(priors[i, :])  # type: ignore
-            axs[i, i].plot(grid, pdf, color=colors[c], lw=2)
 
             axs[i, i].set_xlabel(titles[i], size="small")
             [axs[i, i].tick_params(axis=a, labelsize="x-small") for a in ["x", "y"]]
@@ -406,9 +480,9 @@ def prior_joint(
             axs[i, i].spines[["right", "top"]].set_visible(False)
 
         for i, j in itertools.combinations(range(n_params), 2):
-            grid, pdf, _ = array_stats.kde(priors[i, :])  # type: ignore
-            axs[i, i].plot(grid, pdf, color=colors[c], lw=2)
-            axs[i, j].plot(priors[i, :], priors[j, :], ",", color=colors[c], alpha=0.1)
+            # the column sets the x axis, so the panel shares it with the
+            # density on the diagonal of that column
+            axs[i, j].plot(priors[j, :], priors[i, :], ",", color=colors[c], alpha=0.1)
             [axs[i, j].tick_params(axis=a, labelsize=7) for a in ["x", "y"]]
             axs[j, i].set_axis_off()
             axs[i, j].grid(color="lightgrey", linestyle="dotted", linewidth=1)
@@ -452,13 +526,6 @@ def prior_marginals(
     AttributeError
         Can't find 'prior' in 'eliobj.results'
     """
-    try:
-        from arviz_stats.base import array_stats  # type: ignore
-    except ImportError as exc:
-        raise MissingOptionalDependencyError(
-            "plotting", requirement="arviz_stats"
-        ) from exc
-
     eliobj_res, parallel, n_reps = _check_parallel(eliobj)
     # check chains that yield NaN
     if parallel:
@@ -495,8 +562,9 @@ def prior_marginals(
                 .to_array()
                 .values
             )
-            grid, pdf, _ = array_stats.kde(priors[j, :])  # type: ignore
-            ax.plot(grid, pdf, color="black", lw=2, alpha=0.5)
+            _plot_density(
+                ax, priors[j, :], name_params[j], color="black", lw=2, alpha=0.5
+            )
 
         ax.set_title(f"{title}", fontsize="small")
         ax.tick_params(axis="y", labelsize="x-small")
@@ -926,8 +994,7 @@ def prior_averaging(  # noqa: PLR0913, PLR0915
                 .to_array()
                 .values
             )
-            grid, pdf, _ = array_stats.kde(prior[j, :])  # type: ignore
-            ax.plot(grid, pdf, color="black", lw=2, alpha=0.5)
+            _plot_density(ax, prior[j, :], title, color="black", lw=2, alpha=0.5)
 
         # Plot averaged prior (in red)
         grid, pdf, _ = array_stats.kde(

--- a/tests/unit/test_plots.py
+++ b/tests/unit/test_plots.py
@@ -165,3 +165,66 @@ class TestPlottingFunctions:
         """Test priorpredictive plot with non-existent target."""
         with pytest.raises((ValueError, KeyError)):
             el.plots.priorpredictive(fitted_eliobj, target="nonexistent_target")
+
+
+def test_density_of_a_collapsed_parameter():
+    """two distinct draws have no density; the panel must not raise"""
+    fig, ax = plt.subplots()
+
+    two_values = np.where(np.arange(1000) % 2 == 0, 0.0, 17.5)
+    el.plots._plot_density(ax, two_values, "ts", color="black")
+    # one vertical line per value, instead of a density
+    assert len(ax.lines) == 2
+
+    el.plots._plot_density(ax, np.full(1000, 3.0), "s0", color="black")
+    assert len(ax.lines) == 3
+
+    plt.close(fig)
+
+
+def test_density_leaves_out_non_finite_draws():
+    """a single non-finite draw must not remove the density"""
+    fig, ax = plt.subplots()
+
+    draws = np.concatenate([np.random.default_rng(0).normal(size=999), [np.inf]])
+    el.plots._plot_density(ax, draws, "b", color="black")
+
+    assert len(ax.lines) == 1
+    assert bool(np.isfinite(ax.lines[0].get_xdata()).all())
+    plt.close(fig)
+
+
+def test_prior_joint_survives_a_density_that_fails(fitted_eliobj, monkeypatch):
+    """a density that raises must cost one panel, not the whole figure"""
+    from arviz_stats.base import array_stats
+
+    def failing_kde(ary, **kwargs):
+        msg = "cannot convert float infinity to integer"
+        raise OverflowError(msg)
+
+    monkeypatch.setattr(array_stats, "kde", failing_kde)
+
+    fig, axes = el.plots.prior_joint(fitted_eliobj)
+
+    # every density is empty, and the scatter panels are still drawn
+    assert all(len(axes[i, i].lines) == 0 for i in range(axes.shape[0]))
+    assert len(axes[0, 1].lines) == 1
+    plt.close(fig)
+
+
+def test_prior_joint_panels_share_the_axis_of_their_column(fitted_eliobj):
+    """the scatter of column j uses the parameter of the density in column j"""
+    priors = (
+        fitted_eliobj.results.prior.sel(replication=0)
+        .to_dataset()
+        .to_array()
+        .stack(stacked=("batch", "draw"))
+        .values
+    )
+    fig, axes = el.plots.prior_joint(fitted_eliobj)
+
+    # the column sets x, the row sets y
+    scatter = axes[0, 1].lines[0]
+    np.testing.assert_allclose(scatter.get_xdata(), priors[1], rtol=1e-6)
+    np.testing.assert_allclose(scatter.get_ydata(), priors[0], rtol=1e-6)
+    plt.close(fig)

--- a/tests/unit/test_plots.py
+++ b/tests/unit/test_plots.py
@@ -118,6 +118,20 @@ class TestPlottingFunctions:
         assert [ax.get_xlabel() for ax in np.diag(axes)] == titles
         plt.close(fig)
 
+    def test_prior_joint_params(self, fitted_eliobj):
+        """Test that 'params' selects a subset of the parameters."""
+        names = [param["name"] for param in fitted_eliobj.parameters]
+        selected = [names[2], names[0]]
+        fig, axes = el.plots.prior_joint(fitted_eliobj, params=selected)
+        assert axes.shape == (2, 2)
+        assert [ax.get_xlabel() for ax in np.diag(axes)] == selected
+        plt.close(fig)
+
+    def test_prior_joint_unknown_param(self, fitted_eliobj):
+        """Test that an unknown name in 'params' raises a ValueError."""
+        with pytest.raises(ValueError, match="Unknown parameter"):
+            el.plots.prior_joint(fitted_eliobj, params=["not_a_parameter"])
+
     def test_prior_marginals_plot(self, fitted_eliobj):
         """Test the prior marginals plot function."""
         titles = ["$\beta_0$", "$\beta_1$", r"$\sigma$"]
@@ -126,6 +140,20 @@ class TestPlottingFunctions:
         assert axes.shape == (3,)
         assert [ax.get_title() for ax in axes] == titles
         plt.close(fig)
+
+    def test_prior_marginals_params(self, fitted_eliobj):
+        """Test that 'params' selects a subset of the parameters."""
+        names = [param["name"] for param in fitted_eliobj.parameters]
+        selected = [names[2], names[0]]
+        fig, axes = el.plots.prior_marginals(fitted_eliobj, params=selected)
+        assert axes.shape == (2,)
+        assert [ax.get_title() for ax in axes] == selected
+        plt.close(fig)
+
+    def test_prior_marginals_unknown_param(self, fitted_eliobj):
+        """Test that an unknown name in 'params' raises a ValueError."""
+        with pytest.raises(ValueError, match="Unknown parameter"):
+            el.plots.prior_marginals(fitted_eliobj, params=["not_a_parameter"])
 
     def test_elicits_plot(self, fitted_eliobj):
         """Test elicits plot with custom column layout."""


### PR DESCRIPTION
## Description

`el.plots.prior_joint` raised `OverflowError` for a collapsed parameter. A kernel density needs at least three distinct values. A truncated prior that collapsed onto its bounds has two, and the bandwidth inside `arviz_stats` is
then infinite. 

The off-diagonal panels were transposed. Column `j` showed parameter `i` on its
x-axis, so no column shared the axis of the density on its diagonal.

A model with one parameter could not be plotted: `plt.subplots(1, 1)` returns a single axes, and `axs[i, i]` then raises.

## The fix

New helper `_plot_density`:

- draws one line per value when fewer than three distinct values are left, and names the parameter in the warning;
- leaves out non-finite draws, and reports how many;
- catches a density that fails for any other reason, leaves the panel empty, and reports the range and the standard deviation;
- casts to float64, so the variance of a wide sample stays finite.

## Tests

+ Four new tests: the collapsed parameter, the non-finite draw, a density that raises, and the axis of the column.
