### PR TITLE
Select model parameters in the prior plots

### DIFF
--- a/changelog/51.feature.md
+++ b/changelog/51.feature.md
@@ -1,0 +1,1 @@
+Select a subset of the model parameters in `el.plots.prior_marginals()` and `el.plots.prior_joint()` with the new `params` argument.

--- a/src/elicito/plots.py
+++ b/src/elicito/plots.py
@@ -366,10 +366,46 @@ def hyperparameter(
     return fig, axes
 
 
+def _select_params(name_params: list[str], params: list[str] | None) -> list[str]:
+    """
+    Keep the requested model parameters, in the order of the request
+
+    Parameters
+    ----------
+    name_params
+        names of all model parameters, in the order of the prior samples.
+
+    params
+        names of the requested parameters. If None, all parameters are kept.
+
+    Returns
+    -------
+    :
+        names of the parameters to plot.
+
+    Raises
+    ------
+    ValueError
+        A name in 'params' is not a model parameter.
+
+    """
+    if params is None:
+        return name_params
+
+    unknown = [p for p in params if p not in name_params]
+    if unknown:
+        raise ValueError(
+            f"Unknown parameter(s) {unknown} in 'params'."
+            + f" Available parameters are {name_params}."
+        )
+    return list(params)
+
+
 def prior_joint(
     eliobj: Any,
     idx: int | list[int] | None = None,
     titles: list[str] | None = None,
+    params: list[str] | None = None,
     **kwargs: dict[Any, Any],
 ) -> tuple["matplotlib.figure.Figure", list["matplotlib.axes.Axes"]]:
     """
@@ -391,6 +427,9 @@ def prior_joint(
     titles : list of str, optional
         Labels for the main diagonal. If None, the names of the hyperparameters
         will be used. The length of titles should match the number of hyperparameters.
+    params : list of str, optional
+        names of the model parameters to plot, in the order of the rows and
+        columns. If None, all model parameters are plotted.
     **kwargs : any, optional
         additional keyword arguments that can be passed to specify
         `plt.subplots() <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.subplots.html>`_
@@ -411,6 +450,8 @@ def prior_joint(
         constraint type.
 
         The value for 'idx' is larger than the number of parallelizations.
+
+        A name in 'params' is not a model parameter.
 
     AttributeError
         Can't find 'prior' in 'eliobj.results'
@@ -450,7 +491,7 @@ def prior_joint(
         )
     cmap = mpl.colormaps["turbo"]
     # get parameter names
-    name_params = list(eliobj.results.prior.data_vars)
+    name_params = _select_params(list(eliobj.results.prior.data_vars), params)
     n_params = len(name_params)
     _, _, titles = _get_names_titles(name_params, titles)
 
@@ -464,7 +505,7 @@ def prior_joint(
         # reshape samples by merging batches and number of samples
         priors = (
             eliobj.results.prior.sel(replication=k)
-            .to_dataset()
+            .to_dataset()[name_params]
             .to_array()
             .stack(stacked=("batch", "draw"))
             .values
@@ -493,7 +534,11 @@ def prior_joint(
 
 
 def prior_marginals(
-    eliobj: Any, cols: int = 4, titles: list[str] | None = None, **kwargs: Any
+    eliobj: Any,
+    cols: int = 4,
+    titles: list[str] | None = None,
+    params: list[str] | None = None,
+    **kwargs: Any,
 ) -> tuple["matplotlib.figure.Figure", np.ndarray[Any, Any]]:
     """
     Plot the convergence of each hyperparameter across epochs.
@@ -508,6 +553,9 @@ def prior_marginals(
     titles : list of str, optional
         titles for each subplot. If None, the names of the hyperparameters
         will be used. The length of titles should match the number of hyperparameters.
+    params : list of str, optional
+        names of the model parameters to plot, in the order of the subplots.
+        If None, all model parameters are plotted.
     **kwargs : any, optional
         additional keyword arguments that can be passed to specify
         `plt.subplots() <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.subplots.html>`_
@@ -525,6 +573,9 @@ def prior_marginals(
     ------
     AttributeError
         Can't find 'prior' in 'eliobj.results'
+
+    ValueError
+        A name in 'params' is not a model parameter.
     """
     eliobj_res, parallel, n_reps = _check_parallel(eliobj)
     # check chains that yield NaN
@@ -532,10 +583,10 @@ def prior_marginals(
         _, success, _ = _check_NaN(eliobj, n_reps)
     else:
         success = [0]
+    # get parameter names, and keep only the requested ones
+    name_params = _select_params(list(eliobj.results.prior.data_vars), params)
     # get shape of prior samples
-    n_par = len(list(eliobj.results.prior.data_vars))
-    # get parameter names
-    name_params = list(eliobj.results.prior.data_vars)
+    n_par = len(name_params)
     _, _, titles = _get_names_titles(name_params, titles)
     # prepare plot axes
     (cols, rows, _) = _prep_subplots(eliobj, cols, n_par, bounderies=False)
@@ -557,7 +608,7 @@ def prior_marginals(
         for i in success:
             priors = (
                 eliobj.results.prior.sel(replication=i)
-                .to_dataset()
+                .to_dataset()[name_params]
                 .stack(combined=("batch", "draw"))
                 .to_array()
                 .values

--- a/tests/unit/test_plots.py
+++ b/tests/unit/test_plots.py
@@ -118,6 +118,20 @@ class TestPlottingFunctions:
         assert [ax.get_xlabel() for ax in np.diag(axes)] == titles
         plt.close(fig)
 
+    def test_prior_joint_params(self, fitted_eliobj):
+        """Test that 'params' selects a subset of the parameters."""
+        names = [param["name"] for param in fitted_eliobj.parameters]
+        selected = [names[2], names[0]]
+        fig, axes = el.plots.prior_joint(fitted_eliobj, params=selected)
+        assert axes.shape == (2, 2)
+        assert [ax.get_xlabel() for ax in np.diag(axes)] == selected
+        plt.close(fig)
+
+    def test_prior_joint_unknown_param(self, fitted_eliobj):
+        """Test that an unknown name in 'params' raises a ValueError."""
+        with pytest.raises(ValueError, match="Unknown parameter"):
+            el.plots.prior_joint(fitted_eliobj, params=["not_a_parameter"])
+
     def test_prior_marginals_plot(self, fitted_eliobj):
         """Test the prior marginals plot function."""
         titles = ["$\beta_0$", "$\beta_1$", r"$\sigma$"]
@@ -126,6 +140,20 @@ class TestPlottingFunctions:
         assert axes.shape == (3,)
         assert [ax.get_title() for ax in axes] == titles
         plt.close(fig)
+
+    def test_prior_marginals_params(self, fitted_eliobj):
+        """Test that 'params' selects a subset of the parameters."""
+        names = [param["name"] for param in fitted_eliobj.parameters]
+        selected = [names[2], names[0]]
+        fig, axes = el.plots.prior_marginals(fitted_eliobj, params=selected)
+        assert axes.shape == (2,)
+        assert [ax.get_title() for ax in axes] == selected
+        plt.close(fig)
+
+    def test_prior_marginals_unknown_param(self, fitted_eliobj):
+        """Test that an unknown name in 'params' raises a ValueError."""
+        with pytest.raises(ValueError, match="Unknown parameter"):
+            el.plots.prior_marginals(fitted_eliobj, params=["not_a_parameter"])
 
     def test_elicits_plot(self, fitted_eliobj):
         """Test elicits plot with custom column layout."""


### PR DESCRIPTION
## Description

`el.plots.prior_joint` and `el.plots.prior_marginals` always plotted every model parameter and a user can't select parameters of interest.

## The change

Add a new argument `params` on both functions. It names the parameters of interest to plot.

- The order of the names sets the order of the rows and columns, and of the marginal subplots.
- `None`, the default, keeps every parameter, so the plots do not change for a caller that passes nothing.

Both plots then index the dataset with the selected names, so the samples and the titles stay in the same order.

## Tests

+ Four new tests: the selected subset of `prior_joint`, the selected subset of  `prior_marginals`, and an unknown name for each of the two.
