### PR TITLE
Add derived parameters with el.utils.add_derived()

### DIFF
--- a/changelog/55.feature.md
+++ b/changelog/55.feature.md
@@ -1,0 +1,1 @@
+Add `el.utils.add_derived()`, which stores a derived parameter in the prior samples of a fitted `eliobj`. The plotting functions can then select it by name.

--- a/src/elicito/utils.py
+++ b/src/elicito/utils.py
@@ -5,7 +5,7 @@ helper functions for setting up the Elicit object
 import logging
 import os
 import pickle
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import cloudpickle  # type: ignore
 import tensorflow as tf
@@ -719,6 +719,71 @@ def load(file: str) -> Any:
         eliobj.temp_results = obj["temp_results"]
 
     return eliobj
+
+
+def add_derived(samples: Any, **derived: Callable[[Any], Any]) -> None:
+    """
+    Add derived parameters to the prior samples
+
+    A derived parameter is a function of the model parameters, computed in the
+    generative model and not sampled. It is therefore not in the prior group
+    of the samples. This function computes it from the prior samples and
+    stores it there. The plotting functions can then select it by name.
+
+    Parameters
+    ----------
+    samples
+        result of :func:`elicito.Elicit.sample`. The prior group is changed
+        in place.
+
+    **derived
+        one function per derived parameter, named by the argument. Each
+        function gets the prior samples as an ``xarray.Dataset`` and returns
+        the derived samples.
+
+    Examples
+    --------
+    >>> samples = eliobj.sample()  # doctest: +SKIP
+    >>> el.utils.add_derived(  # doctest: +SKIP
+    ...     samples,
+    ...     h1=lambda prior: prior["hts"] + prior["dh"],
+    ... )
+    >>> el.plots.prior_marginals(  # doctest: +SKIP
+    ...     eliobj, params=["h1", "hts"], samples=samples
+    ... )
+
+    Raises
+    ------
+    KeyError
+        Can't find 'prior' in the samples.
+
+    ValueError
+        A name in ``derived`` is already a model parameter.
+
+    """
+    try:
+        prior = samples["prior"]
+    except KeyError:
+        raise KeyError(  # noqa: TRY003
+            "No 'prior' group found. Pass the result of 'eliobj.sample()'."
+        )
+
+    model_params = prior.attrs["model_parameters"]
+    # `to_dataset` copies the samples out of the DataTree node, so the new
+    # variables are written back with the setter below
+    prior_samples = prior.to_dataset()
+
+    for name, function in derived.items():
+        if name in model_params:
+            raise ValueError(
+                f"'{name}' is a model parameter. A derived parameter needs"
+                + " a name of its own."
+            )
+        if name in prior_samples.data_vars:
+            logger.info(f"Replacing the derived parameter '{name}'.")
+        prior_samples[name] = function(prior_samples)
+
+    samples["prior"].dataset = prior_samples
 
 
 def parallel(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -28,6 +28,61 @@ from elicito.utils import (
 tfd = tfp.distributions
 
 
+@pytest.fixture
+def fitted_eliobj():
+    """Fixture providing a fitted elicit object for testing."""
+    from tests.utils import eliobj as base_eliobj
+
+    eliobj_copy = el.Elicit(
+        model=base_eliobj.model,
+        parameters=base_eliobj.parameters,
+        targets=base_eliobj.targets,
+        expert=base_eliobj.expert,
+        optimizer=base_eliobj.optimizer,
+        trainer=el.trainer(method="parametric_prior", seed=0, epochs=1, progress=0),
+        initializer=el.initializer(
+            method="sobol",
+            iterations=1,
+            distribution=el.initialization.uniform(radius=1.0, mean=0.0),
+        ),
+    )
+    eliobj_copy.fit()
+    return eliobj_copy
+
+
+def test_add_derived(fitted_eliobj):
+    """Test that a derived parameter is added to the prior samples."""
+    draws = fitted_eliobj.sample()
+    names = list(draws["prior"].data_vars)
+
+    el.utils.add_derived(draws, total=lambda prior: prior[names[0]] + prior[names[1]])
+
+    samples = draws["prior"].to_dataset()
+    assert "total" in samples.data_vars
+    np.testing.assert_allclose(
+        samples["total"].values, (samples[names[0]] + samples[names[1]]).values
+    )
+    # the derived parameter can be selected in the plots
+    assert [*names, "total"] == list(samples.data_vars)
+
+
+def test_add_derived_rejects_model_parameter(fitted_eliobj):
+    """Test that a derived parameter can't overwrite a model parameter."""
+    draws = fitted_eliobj.sample()
+    name = fitted_eliobj.parameters[0]["name"]
+
+    with pytest.raises(ValueError, match="is a model parameter"):
+        el.utils.add_derived(draws, **{name: lambda prior: prior[name]})
+
+
+def test_add_derived_requires_samples():
+    """Test that a tree without a prior group raises a KeyError."""
+    tree = xr.DataTree(name="samples")
+
+    with pytest.raises(KeyError, match="No 'prior' group found"):
+        el.utils.add_derived(tree, total=lambda prior: prior)
+
+
 def test_save_as_pkl():
     test_object = xr.DataTree(xr.Dataset({"a": 1, "b": [1, 2, 3]}))
     test_path = "tests/test-data/test_object.pkl"


### PR DESCRIPTION
## Description

A derived parameter is a function of the model parameters, computed inside the generative model. It is therefore absent from the `prior` group of `eliobj.sample()`. `el.utils.add_derived()` computes it from the prior
samples and writes it back, so `plots.prior_marginals(params=...)` can select it by name.

```python
samples = eliobj.sample()
el.utils.add_derived(samples, h1=lambda prior: prior["hts"] + prior["dh"])
el.plots.prior_marginals(eliobj, params=["h1", "hts"], samples=samples)
```

## Contract

- `KeyError` if the argument is not a `sample()` result.
- `ValueError` if the name is already a model parameter.
- A repeated name replaces the earlier one