### PR TITLE
Add CMA-ES for the initialization and the training

### DIFF
--- a/changelog/56.feature.1.md
+++ b/changelog/56.feature.1.md
@@ -1,0 +1,9 @@
+Added CMA-ES as an alternative to the gradient descent for `method="parametric_prior"`.
+Select it with `el.optimizer(optimizer="cmaes", sigma0=...)`.
+The search needs no gradient, so it cannot diverge, and it can leave a local basin.
+`trainer(epochs=...)` is then the budget in forward simulations.
+`sigma0` also takes a dictionary `{hyperparameter name: step size}`, for a model
+whose hyperparameters do not live on the same scale.
+With `el.initializer(method="cmaes")`, the initialization runs no search of its
+own. It only reads the box, which gives the training its start point and its
+first step size per hyperparameter. `iterations` is then not used.

--- a/changelog/56.feature.md
+++ b/changelog/56.feature.md
@@ -1,0 +1,6 @@
+Added `el.initializer(method="cmaes")`, a global search for the start values
+with CMA-ES. It reads the whole initialization box, not only its centre, and
+keeps every candidate inside it. Use it when you cannot place the box around
+the answer: the samplers and the Nelder-Mead warm start take the first basin
+they meet, which need not be the best one. It needs the optional dependency
+`cma`, and its default budget is 500 objective evaluations.

--- a/changelog/56.fix.md
+++ b/changelog/56.fix.md
@@ -1,0 +1,10 @@
+`el.plots.hyperparameter` works again after a fit whose initializer draws no
+candidates.
+
+It read the hyperparameter names from `results.initialization`, and
+`el.initializer(method="cmaes")` writes no such group. The call ended in
+`AttributeError: 'DataTree' object has no attribute 'initialization'`. The
+names now come from the model, in the order the initializer uses.
+
+`el.plots.initialization` needs that group, and says so instead of raising the
+same `AttributeError`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ scipy = [
     "scipy>=1.14.0"
 ]
 cma = [
-    "cma>=3.3.0"
+    "cma>=3.4.0"
 ]
 
 full = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,10 +51,14 @@ plots = [
 scipy = [
     "scipy>=1.14.0"
 ]
+cma = [
+    "cma>=3.3.0"
+]
 
 full = [
     "elicito[plots]",
     "elicito[scipy]",
+    "elicito[cma]",
 ]
 
 [dependency-groups]

--- a/src/elicito/__init__.py
+++ b/src/elicito/__init__.py
@@ -4,6 +4,7 @@ A Python package for learning prior distributions based on expert knowledge
 
 import importlib.metadata
 from collections import defaultdict
+from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any
 
@@ -14,6 +15,7 @@ import tensorflow_probability as tfp  # type: ignore
 from elicito import (
     _checks,
     _outputs,
+    cmaes,
     elicit,
     initialization,
     losses,
@@ -58,6 +60,7 @@ __version__ = importlib.metadata.version("elicito")
 
 __all__ = [
     "Elicit",
+    "cmaes",
     "expert",
     "hyper",
     "initialization",
@@ -270,8 +273,16 @@ class Elicit:
         else:
             targets_str = names_str
 
-        opt_name = self.optimizer["optimizer"].__name__
-        opt_lr = self.optimizer["learning_rate"]
+        if self.optimizer["optimizer"] == cmaes.CMAES:
+            sigma0 = self.optimizer.get("sigma0", cmaes.DEFAULT_SIGMA0)
+            if isinstance(sigma0, dict):
+                # a step size per hyperparameter is too long for one line
+                sigma0 = f"{len(sigma0)} values"
+            opt_str = f"{cmaes.CMAES}(sigma0={sigma0})"
+        else:
+            opt_name = self.optimizer["optimizer"].__name__
+            opt_lr = self.optimizer["learning_rate"]
+            opt_str = f"{opt_name}(lr={opt_lr})"
 
         get_num_hyperpar: int | str
         if hasattr(self, "results") and self.trainer["method"] == "deep_prior":
@@ -309,7 +320,7 @@ class Elicit:
             f"Epochs: {self.trainer['epochs']}\n"
             f"Method: {self.trainer['method']}\n"
             f"Seed: {self.trainer['seed']}\n"
-            f"Optimizer: {opt_name}(lr={opt_lr})\n"
+            f"Optimizer: {opt_str}\n"
         )
         if self.trainer["method"] == "parametric_prior":
             if self.initializer is not None:
@@ -703,7 +714,22 @@ class Elicit:
         # run dag with optimal set of initial values
         # save results in corresp. attributes
 
-        history, results = optimization.sgd_training(
+        # the optimizer is either a tf.keras class, or the name of a
+        # derivative-free search
+        extra: dict[str, Any] = {}
+        fit_method: Callable[..., tuple[dict[Any, Any], dict[Any, Any]]]
+        if self.optimizer["optimizer"] == cmaes.CMAES:
+            fit_method = cmaes.cma_training
+            # the search starts where the initialization stopped. If the
+            # initialization only read the box, the box also sets the first
+            # step size of each coordinate.
+            extra["default_sigma0"] = cmaes.box_step_size(
+                self.initializer, expert_elicits, self.parameters
+            )
+        else:
+            fit_method = optimization.sgd_training
+
+        history, results = fit_method(
             expert_elicits,
             init_prior_model,
             self.trainer,
@@ -713,6 +739,7 @@ class Elicit:
             self.parameters,
             seed,
             self.trainer["progress"],
+            **extra,
         )
         # add some additional results
         results["expert_elicited_statistics"] = expert_elicits

--- a/src/elicito/_checks.py
+++ b/src/elicito/_checks.py
@@ -2,7 +2,7 @@
 Check user input of Elicit object
 """
 
-from elicito import methods, utils
+from elicito import cmaes, methods, utils
 
 
 def check_elicit(  # type: ignore  # noqa: PLR0913
@@ -60,6 +60,29 @@ def check_elicit(  # type: ignore  # noqa: PLR0913
                 f"{len(expected_params)}."
             )
             raise AssertionError(msg)
+
+    # CMA-ES keeps a full covariance matrix of the search space. The weights
+    # of a normalizing flow are thousands of dimensions, which it cannot search.
+    if optimizer["optimizer"] == cmaes.CMAES and trainer["method"] == "deep_prior":
+        msg = (
+            f"optimizer='{cmaes.CMAES}' can only be used with "
+            "method='parametric_prior'. The 'deep_prior' method has too many "
+            "trainable variables for a derivative-free search. Use a "
+            "tf.keras optimizer instead."
+        )
+        raise ValueError(msg)
+
+    if (
+        optimizer["optimizer"] == cmaes.CMAES
+        and initializer is not None
+        and initializer["warmup_epochs"] > 0
+    ):
+        msg = (
+            f"optimizer='{cmaes.CMAES}' cannot be combined with "
+            "initializer(warmup_epochs=...). The warm-up of a candidate is a "
+            "gradient run. Set warmup_epochs=0."
+        )
+        raise ValueError(msg)
 
     # let the method validate its own sections
     methods.get_method(trainer["method"]).check(parameters, network, initializer)

--- a/src/elicito/_outputs.py
+++ b/src/elicito/_outputs.py
@@ -235,13 +235,18 @@ def create_hyperparameter_group(history: list[Any]) -> xr.Dataset:
         }
     )
 
-    ds_hyp_grad = to_dataset(
-        obj=history,
-        group="hyperparameter_gradient",
-        dims=MAIN_DIMS,
-        names_subgroups=[f"grad_{k}" for k in hyp_names],
-    )
-    hyp_group = ds_hyp.merge(ds_hyp_grad)
+    # a derivative-free fitter, such as CMA-ES, records no gradient
+    has_gradients = any(rep.get("hyperparameter_gradient") for rep in history)
+    if has_gradients:
+        ds_hyp_grad = to_dataset(
+            obj=history,
+            group="hyperparameter_gradient",
+            dims=MAIN_DIMS,
+            names_subgroups=[f"grad_{k}" for k in hyp_names],
+        )
+        hyp_group = ds_hyp.merge(ds_hyp_grad)
+    else:
+        hyp_group = ds_hyp
 
     hyp_group = hyp_group.assign_coords(create_hist_corrds(history))
     hyp_group = hyp_group.assign_attrs(

--- a/src/elicito/cmaes.py
+++ b/src/elicito/cmaes.py
@@ -1,0 +1,506 @@
+"""
+Global search for the hyperparameters of a parametric prior, with CMA-ES
+"""
+
+import logging
+import time
+from typing import Any
+
+import numpy as np
+import tensorflow as tf
+from tqdm import tqdm
+
+import elicito as el
+from elicito.exceptions import MissingOptionalDependencyError
+from elicito.types import ExpertDict, Parameter, Target, Trainer
+
+logger = logging.getLogger(__name__)
+
+# Step size of the first generation, as a share of the box radius. CMA-ES
+# adapts the step size afterwards. Half the radius covers the box, and keeps
+# most of the first generation inside it.
+SIGMA_FRACTION = 2.0
+
+# First step size of `cma_training`, on the unconstrained scale. The fitter
+# has no box to read a scale from, so the value is a setting of the optimizer.
+DEFAULT_SIGMA0 = 0.5
+
+# Value of `el.optimizer(optimizer=...)` that selects the CMA-ES fitter
+CMAES = "cmaes"
+
+
+def cma_search(  # noqa: PLR0913
+    expert_elicited_statistics: dict[str, tf.Tensor],
+    parameters: list[Parameter],
+    trainer: Trainer,
+    model: dict[str, Any],
+    targets: list[Target],
+    expert: ExpertDict,
+    distribution: dict[str, Any],
+    max_evals: int,
+    seed: int,
+) -> dict[str, Any]:
+    """
+    Search a start value with CMA-ES, before any gradient step
+
+    The search reads the whole initialization box, not only its centre. It
+    starts at the centre, with a step size of half the radius, and it keeps
+    every candidate inside the box. It needs no gradient, so it cannot diverge
+    through an exploding gradient.
+
+    Use this method when you cannot place the box around the answer. A wide
+    box gives the two local methods, ``warmstart`` and the box samplers, the
+    first basin they meet, which is not the best one. Measured on the human
+    growth model, from a box of radius 5 around zero, the warm start ended at
+    a loss of 482.9 and CMA-ES at 27.7, in about the same number of
+    evaluations.
+
+    Parameters
+    ----------
+    expert_elicited_statistics
+        Elicited statistics of the expert.
+
+    parameters
+        List including dictionary with all information about the
+        (hyper-)parameters.
+
+    trainer
+        Specification of trainer settings.
+
+    model
+        Generative model.
+
+    targets
+        Elicitation techniques and target quantities.
+
+    expert
+        Expert specification.
+
+    distribution
+        Initialization box. Its centre is the start point of the search, and
+        its radius sets both the step size and the bounds.
+
+    max_evals
+        Budget, in objective evaluations. The search stops at the end of the
+        generation that reaches the budget, so it can use a few more.
+
+    seed
+        Seed used for the forward simulation.
+
+    Raises
+    ------
+    MissingOptionalDependencyError
+        ``cma`` is required for the search.
+
+    Returns
+    -------
+    hyperparams :
+        One value per hyperparameter, on the unconstrained scale.
+
+    """
+    try:
+        import cma  # type: ignore [import-untyped]
+    except ImportError as exc:
+        raise MissingOptionalDependencyError("cma_search", requirement="cma") from exc
+
+    names = el.initialization.hyper_names(parameters)
+    box = el.initialization.build_box(
+        distribution, expert_elicited_statistics, parameters
+    )
+
+    search_trainer = dict(trainer)
+    search_trainer["num_samples"] = max(
+        el.warmstart.MIN_SEARCH_SAMPLES,
+        trainer["num_samples"] // el.warmstart.SEARCH_FRACTION,
+    )
+
+    centre = np.asarray(el.warmstart._box_vector(box, names, "mean"), dtype=np.float64)
+    radius = np.asarray(
+        el.warmstart._box_vector(box, names, "radius"), dtype=np.float64
+    )
+
+    # CMA-ES uses one step size for every coordinate. A box with a different
+    # radius per hyperparameter is handled by `CMA_stds`, which rescales each
+    # coordinate. The step size of coordinate i is then sigma0 * radius[i].
+    options = {
+        "CMA_stds": radius,
+        "bounds": [centre - radius, centre + radius],
+        "maxfevals": max_evals,
+        # cma reads a seed of 0 as "draw a random seed"
+        "seed": int(seed) + 1,
+        "verbose": -9,
+        "verb_log": 0,
+    }
+
+    # A failed point is scored as a large finite number, so the last generation
+    # can be worse than a point seen before. Keep the best usable point.
+    best: dict[str, Any] = {"value": el.warmstart.PENALTY, "values": None}
+
+    scorer = el.warmstart.compile_score(
+        expert_elicited_statistics=expert_elicited_statistics,
+        parameters=parameters,
+        trainer=search_trainer,  # type: ignore [arg-type]
+        model=model,
+        targets=targets,
+        expert=expert,
+        seed=seed,
+    )
+
+    def objective(values: Any) -> float:
+        value = float(scorer(dict(zip(names, values))))
+        if value < best["value"]:
+            best["value"] = value
+            best["values"] = np.array(values, dtype=np.float64)
+        return value
+
+    strategy = cma.CMAEvolutionStrategy(centre, 1.0 / SIGMA_FRACTION, options)
+    used = 0
+    while used < max_evals and not strategy.stop():
+        candidates = strategy.ask()
+        losses = [objective(candidate) for candidate in candidates]
+        used += len(candidates)
+        strategy.tell(candidates, losses)
+
+    if best["values"] is None:
+        logger.warning(
+            "CMA-ES: every evaluated point failed. The centre of the "
+            "initialization box is used as the start value. Re-centre the "
+            "box, or reduce its radius."
+        )
+        values = centre
+    else:
+        logger.info(f"CMA-ES: loss {best['value']:.4f} after {used} evaluations.")
+        values = best["values"]
+
+    return {name: float(value) for name, value in zip(names, values)}
+
+
+def box_step_size(
+    initializer: Any,
+    expert_elicited_statistics: dict[str, tf.Tensor],
+    parameters: list[Parameter],
+) -> Any:
+    """
+    Read the first step size of the training out of the initialization box
+
+    The box states the scale of every hyperparameter. A coordinate with a
+    wide radius needs a wide first step. The box is only a scale and a start
+    point here: it does not bound the search.
+
+    Parameters
+    ----------
+    initializer
+        Specification of the initialization method.
+
+    expert_elicited_statistics
+        Elicited statistics of the expert. The default box reads their scale.
+
+    parameters
+        List including dictionary with all information about the
+        (hyper-)parameters.
+
+    Returns
+    -------
+    sigma0 :
+        Step size per hyperparameter name, or ``DEFAULT_SIGMA0`` if the
+        initialization method does not hand its box to the training.
+
+    """
+    method = el.initialization.resolve_init_method(initializer)
+    if not method.skips_search(dict(optimizer=CMAES)):
+        return DEFAULT_SIGMA0
+
+    names = el.initialization.hyper_names(parameters)
+    box = el.initialization.build_box(
+        dict(initializer["distribution"]), expert_elicited_statistics, parameters
+    )
+    radius = el.warmstart._box_vector(box, names, "radius")
+    return {name: value / SIGMA_FRACTION for name, value in zip(names, radius)}
+
+
+def _step_size(
+    sigma0: Any, names: list[str], default: Any = DEFAULT_SIGMA0
+) -> tuple[float, list[float] | None]:
+    """
+    Split the ``sigma0`` setting into a scalar and a per-coordinate vector
+
+    CMA-ES uses one step size for every coordinate. A different step size per
+    hyperparameter is handled by ``CMA_stds``, which rescales each coordinate.
+    The step size of coordinate i is then ``sigma0 * CMA_stds[i]``, so a
+    per-hyperparameter setting keeps the scalar at 1.0.
+
+    Parameters
+    ----------
+    sigma0
+        One step size for every coordinate, or a step size per hyperparameter
+        name. A name that is not given gets its step size from ``default``.
+
+    names
+        Hyperparameter name of each trainable variable.
+
+    default
+        Step size of a hyperparameter that ``sigma0`` does not name. One
+        number, or one number per hyperparameter name.
+
+    Raises
+    ------
+    ValueError
+        A key of ``sigma0`` is not a hyperparameter of the model.
+
+    Returns
+    -------
+    sigma0 :
+        First step size, as one number.
+
+    stds :
+        One multiplier per coordinate, or None if ``sigma0`` is a number.
+
+    """
+    if not isinstance(sigma0, dict):
+        return float(sigma0), None
+
+    unknown = sorted(set(sigma0) - set(names))
+    if unknown:
+        msg = (
+            f"optimizer(sigma0=...) has the unknown hyperparameter(s) "
+            f"{unknown}. The hyperparameters of this model are "
+            f"{sorted(set(names))}."
+        )
+        raise ValueError(msg)
+
+    if not isinstance(default, dict):
+        default = dict.fromkeys(names, default)
+    stds = [
+        float(sigma0.get(name, default.get(name, DEFAULT_SIGMA0))) for name in names
+    ]
+    return 1.0, stds
+
+
+def cma_training(  # noqa: PLR0913, PLR0915
+    expert_elicited_statistics: dict[str, tf.Tensor],
+    prior_model_init: Any,
+    trainer: Trainer,
+    optimizer: dict[str, Any],
+    model: dict[str, Any],
+    targets: list[Target],
+    parameters: list[Parameter],
+    seed: int,
+    progress: int,
+    default_sigma0: Any = DEFAULT_SIGMA0,
+) -> tuple[dict[Any, Any], dict[Any, Any]]:
+    """
+    Fit the hyperparameters of a parametric prior with CMA-ES
+
+    The search replaces the gradient descent of
+    [`sgd_training`][elicito.optimization.sgd_training]. It needs no gradient,
+    so it cannot diverge through an exploding gradient, and it can leave a
+    local basin that a gradient step cannot leave. It costs more forward
+    simulations for the same number of history points, because one generation
+    needs one simulation per candidate.
+
+    The search starts at the values that the initialization produced. It is
+    not bounded. Every candidate is scored on the same seed, so two candidates
+    differ only in their hyperparameters.
+
+    The two return values have the same structure as those of
+    ``sgd_training``, with one generation in the place of one epoch. The
+    gradient history is empty.
+
+    Parameters
+    ----------
+    expert_elicited_statistics
+        Elicited statistics of the expert.
+
+    prior_model_init
+        Initialized prior model. Its variables hold the start value.
+
+    trainer
+        Settings for the optimization phase. ``epochs`` is read as the budget
+        in forward simulations.
+
+    optimizer
+        Settings of the search. ``sigma0`` is the first step size, on the
+        unconstrained scale. ``popsize`` is the number of candidates in one
+        generation; the CMA-ES rule is used if it is not given.
+
+    model
+        Generative model.
+
+    targets
+        List of target quantities.
+
+    parameters
+        List of model parameters.
+
+    seed
+        Internally used seed for reproducible results.
+
+    progress
+        Whether the progress of the training is printed.
+
+    default_sigma0
+        First step size, used if ``optimizer`` does not give ``sigma0``. See
+        [`box_step_size`][elicito.cmaes.box_step_size].
+
+    Raises
+    ------
+    MissingOptionalDependencyError
+        ``cma`` is required for the search.
+
+    Returns
+    -------
+    res_ep :
+        Results saved for each generation (history).
+
+    output_res :
+        Results of the best point found (results).
+
+    """
+    try:
+        import cma
+    except ImportError as exc:
+        raise MissingOptionalDependencyError("cma_training", requirement="cma") from exc
+
+    tf.random.set_seed(seed)
+
+    prior_model = prior_model_init
+    method = el.methods.get_method(trainer["method"])
+    res_dict = method.new_history(prior_model, parameters)
+    # the same objects during the whole run, so an assignment reaches the
+    # prior model
+    variables = method.trainable_variables(prior_model)
+
+    start = [float(var.numpy()) for var in variables]
+    budget = int(trainer["epochs"])
+
+    options: dict[str, Any] = {
+        "maxfevals": budget,
+        # cma reads a seed of 0 as "draw a random seed"
+        "seed": int(seed) + 1,
+        "verbose": -9,
+        "verb_log": 0,
+    }
+    if optimizer.get("popsize") is not None:
+        options["popsize"] = int(optimizer["popsize"])
+
+    # the box sets the step size of a hyperparameter that `sigma0` does not
+    # name, so a partial `sigma0` overrides the box one coordinate at a time
+    sigma0, stds = _step_size(
+        optimizer.get("sigma0", default_sigma0),
+        el.warmstart._variable_names(variables),
+        default_sigma0,
+    )
+    if stds is not None:
+        options["CMA_stds"] = stds
+
+    def assign(values: Any) -> None:
+        for var, value in zip(variables, values):
+            var.assign(tf.constant(float(value), dtype=var.dtype))
+
+    # traced once, then re-used. The graph reads the variables, so `assign`
+    # reaches the next simulation.
+    run = el.warmstart.compile_evaluate(
+        prior_model, model, targets, expert_elicited_statistics, seed
+    )
+
+    kappa = trainer.get("kappa", 0.0)
+
+    def objective(values: Any) -> tuple[float, dict[str, Any]]:
+        assign(values)
+        value, output = el.warmstart.evaluate(
+            prior_model=prior_model,
+            expert_elicited_statistics=expert_elicited_statistics,
+            model=model,
+            targets=targets,
+            seed=seed,
+            run=run,
+        )
+        # the penalty enters the score of the search, not the recorded loss.
+        # A failed point already carries the PENALTY sentinel, and must keep
+        # its order against the usable points.
+        if kappa and value < el.warmstart.PENALTY:
+            value += kappa * float(el.losses.spread_penalty(output["prior_samples"]))
+        return value, output
+
+    total_losses = []
+    component_losses = []
+    penalties = []
+    time_per_epoch = []
+
+    # A failed point is scored as a large finite number, so a later point can
+    # be worse than a point seen before. Keep the best usable point.
+    best: dict[str, Any] = {"value": el.warmstart.PENALTY, "values": None}
+
+    if progress != 0:
+        print("Training")
+        bar = tqdm(total=budget)
+
+    strategy = cma.CMAEvolutionStrategy(start, sigma0, options)
+    used = 0
+    while used < budget and not strategy.stop():
+        generation_time_start = time.time()
+
+        candidates = strategy.ask()
+        losses = []
+        leader: dict[str, Any] = {"value": None, "values": None, "output": None}
+        for candidate in candidates:
+            value, output = objective(candidate)
+            losses.append(value)
+            if leader["value"] is None or value < leader["value"]:
+                leader = {"value": value, "values": candidate, "output": output}
+            if value < best["value"]:
+                best = {
+                    "value": value,
+                    "values": np.array(candidate, dtype=np.float64),
+                    "output": output,
+                }
+        used += len(candidates)
+        strategy.tell(candidates, losses)
+
+        # the history point is the best candidate of this generation. Its
+        # loss and its hyperparameter values then describe the same point.
+        assign(leader["values"])
+        method.record_epoch(
+            res_dict, leader["output"]["prior_samples"], variables, parameters
+        )
+        # the history keeps the score of the search, not the raw loss. A
+        # point whose forward simulation overflows carries a small raw loss,
+        # and would else read as progress.
+        total_losses.append(tf.cast(leader["value"], leader["output"]["loss"].dtype))
+        component_losses.append(leader["output"]["loss_component"])
+        penalties.append(el.losses.spread_penalty(leader["output"]["prior_samples"]))
+        time_per_epoch.append(time.time() - generation_time_start)
+
+        if progress != 0:
+            bar.update(len(candidates))
+
+    if progress != 0:
+        bar.close()
+
+    if best["values"] is None:
+        logger.warning(
+            "CMA-ES: every evaluated point failed. The start value is kept."
+            " Re-check the initialization, or the generative model."
+        )
+        final = start
+    else:
+        logger.info(f"CMA-ES: loss {best['value']:.4f} after {used} evaluations.")
+        final = list(best["values"])
+
+    # the results must describe the point that the run returns
+    (_, output) = objective(final)
+
+    res_ep = {
+        "loss": total_losses,
+        "loss_component": component_losses,
+        "penalty": penalties,
+        "time": time_per_epoch,
+        "hyperparameter": res_dict,
+    }
+    output_res = {
+        key: output[key] for key in output if key not in ("loss", "loss_component")
+    }
+
+    method.finalize(res_ep, output_res, [], variables)
+
+    return res_ep, output_res

--- a/src/elicito/elicit.py
+++ b/src/elicito/elicit.py
@@ -697,7 +697,22 @@ def optimizer(
     ----------
     optimizer
         Optimizer used for SGD implemented.
-        Must be a class implemented in [`tf.keras.optimizers`](https://www.tensorflow.org/api_docs/python/tf/keras/optimizers)
+        Must be a class implemented in [`tf.keras.optimizers`](https://www.tensorflow.org/api_docs/python/tf/keras/optimizers),
+        or the string ``"cmaes"``.
+
+        ``"cmaes"`` replaces the gradient descent by a CMA-ES search
+        ([`cma_training`][elicito.cmaes.cma_training]). It needs no gradient,
+        and it can leave a local basin. It is available for
+        ``method="parametric_prior"`` only, and it needs the optional
+        ``cma`` dependency. Its settings are ``sigma0``, the first step size
+        on the unconstrained scale, and ``popsize``, the number of candidates
+        in one generation. ``trainer(epochs=...)`` is then the budget in
+        forward simulations, not the number of generations.
+
+        ``sigma0`` is one number for every coordinate. Give a dictionary
+        ``{hyperparameter name: step size}`` if the hyperparameters do not
+        live on the same scale. A name that is not given gets the default
+        step size. An unknown name raises a ``ValueError``.
 
     **kwargs
         Additional keyword arguments expected by **optimizer**.
@@ -720,6 +735,16 @@ def optimizer(
     >>>     optimizer=tf.keras.optimizers.Adam,  # doctest: +SKIP
     >>>     learning_rate=0.1,  # doctest: +SKIP
     >>>     clipnorm=1.0  # doctest: +SKIP
+    >>> )  # doctest: +SKIP
+
+    >>> optimizer = el.optimizer(  # doctest: +SKIP
+    >>>     optimizer="cmaes",  # doctest: +SKIP
+    >>>     sigma0=0.5,  # doctest: +SKIP
+    >>> )  # doctest: +SKIP
+
+    >>> optimizer = el.optimizer(  # doctest: +SKIP
+    >>>     optimizer="cmaes",  # doctest: +SKIP
+    >>>     sigma0=dict(a_ts=0.1, b_ts=0.5),  # doctest: +SKIP
     >>> )  # doctest: +SKIP
     """
     optimizer_dict = dict(optimizer=optimizer)

--- a/src/elicito/initialization.py
+++ b/src/elicito/initialization.py
@@ -67,6 +67,10 @@ class InitMethod(Protocol):
         """Reject an input this method cannot use."""
         ...
 
+    def skips_search(self, optimizer: dict[str, Any]) -> bool:
+        """Whether the training repeats this search, so it can be dropped."""
+        ...
+
     def propose(  # noqa: PLR0913
         self,
         expert_elicited_statistics: dict[str, tf.Tensor],
@@ -140,6 +144,10 @@ class ExactValues:
         if initializer["hyperparams"] is None:
             msg = "Method 'exact' needs 'hyperparams'."
             raise ValueError(msg)
+
+    def skips_search(self, optimizer: dict[str, Any]) -> bool:
+        """Whether the training repeats this search, so it can be dropped."""
+        return False
 
     def propose(  # noqa: PLR0913
         self,
@@ -231,6 +239,10 @@ class BoxSample:
         """Reject an input this method cannot use."""
         _check_box(initializer)
 
+    def skips_search(self, optimizer: dict[str, Any]) -> bool:
+        """Whether the training repeats this search, so it can be dropped."""
+        return False
+
     def propose(  # noqa: PLR0913
         self,
         expert_elicited_statistics: dict[str, tf.Tensor],
@@ -289,15 +301,34 @@ for _sampler in ("sobol", "lhs", "random"):
     _INIT_METHODS[_sampler] = BoxSample
 
 
-class WarmStart:
-    """Search for a start point with Nelder-Mead, from the box centre."""
+class _SearchStart:
+    """A start value that a derivative-free search picks out of the box."""
 
-    name = "warmstart"
-    default_iterations = 100  # objective evaluations, not candidates
+    name: str
+    default_iterations: int
 
     def check(self, initializer: Initializer) -> None:
         """Reject an input this method cannot use."""
         _check_box(initializer)
+
+    def skips_search(self, optimizer: dict[str, Any]) -> bool:
+        """Whether the training repeats this search, so it can be dropped."""
+        return False
+
+    def search(  # noqa: PLR0913
+        self,
+        expert_elicited_statistics: dict[str, tf.Tensor],
+        parameters: list[Parameter],
+        trainer: Trainer,
+        model: dict[str, Any],
+        targets: list[Target],
+        expert: ExpertDict,
+        distribution: dict[str, Any],
+        max_evals: int,
+        seed: int,
+    ) -> dict[str, Any]:
+        """Return one value per hyperparameter, on the unconstrained scale."""
+        raise NotImplementedError
 
     def propose(  # noqa: PLR0913
         self,
@@ -318,24 +349,34 @@ class WarmStart:
         iterations = initializer["iterations"]
         if distribution is None or iterations is None:
             # check() rejects this earlier; the guard narrows the type
-            msg = "Method 'warmstart' needs 'distribution' and 'iterations'."
+            msg = f"Method {self.name!r} needs 'distribution' and 'iterations'."
             raise ValueError(msg)
 
         # a derivative-free search needs no gradient, so it cannot diverge.
         # The copy keeps the user's Elicit object unchanged.
         initializer = dict(initializer)  # type: ignore [assignment]
-        initializer["hyperparams"] = el.warmstart.warm_start(
-            expert_elicited_statistics=expert_elicited_statistics,
-            parameters=parameters,
-            trainer=trainer,
-            model=model,
-            targets=targets,
-            expert=expert,
-            # dict() satisfies the signature; a TypedDict is invariant
-            distribution=dict(distribution),
-            max_evals=iterations,
-            seed=seed,
-        )
+        if self.skips_search(optimizer):
+            logger.info(
+                f"{self.name}: the training runs the same search, so the "
+                "initialization only reads the box. 'iterations' is not used."
+            )
+            names = hyper_names(parameters)
+            box = build_box(dict(distribution), expert_elicited_statistics, parameters)
+            centre = el.warmstart._box_vector(box, names, "mean")
+            initializer["hyperparams"] = dict(zip(names, centre))
+        else:
+            initializer["hyperparams"] = self.search(
+                expert_elicited_statistics=expert_elicited_statistics,
+                parameters=parameters,
+                trainer=trainer,
+                model=model,
+                targets=targets,
+                expert=expert,
+                # dict() satisfies the signature; a TypedDict is invariant
+                distribution=dict(distribution),
+                max_evals=iterations,
+                seed=seed,
+            )
         return ExactValues().propose(
             expert_elicited_statistics=expert_elicited_statistics,
             initializer=initializer,
@@ -357,14 +398,93 @@ class WarmStart:
         trainer: Trainer,
     ) -> Any:
         """Return a slice of the right shape for ``Elicit.__init__``."""
-        # the dry run only needs a slice of the right shape. The warm start
-        # searches for the real values during `fit`.
+        # the dry run only needs a slice of the right shape. The search
+        # looks for the real values during `fit`.
         initializer = dict(initializer)  # type: ignore [assignment]
         initializer["method"] = "random"
         return BoxSample().dry_run_slice(initializer, parameters, trainer)
 
 
+class WarmStart(_SearchStart):
+    """Search for a start point with Nelder-Mead, from the box centre."""
+
+    name = "warmstart"
+    default_iterations = 100  # objective evaluations, not candidates
+
+    def search(  # noqa: PLR0913
+        self,
+        expert_elicited_statistics: dict[str, tf.Tensor],
+        parameters: list[Parameter],
+        trainer: Trainer,
+        model: dict[str, Any],
+        targets: list[Target],
+        expert: ExpertDict,
+        distribution: dict[str, Any],
+        max_evals: int,
+        seed: int,
+    ) -> dict[str, Any]:
+        """Return one value per hyperparameter, on the unconstrained scale."""
+        return el.warmstart.warm_start(
+            expert_elicited_statistics=expert_elicited_statistics,
+            parameters=parameters,
+            trainer=trainer,
+            model=model,
+            targets=targets,
+            expert=expert,
+            distribution=distribution,
+            max_evals=max_evals,
+            seed=seed,
+        )
+
+
 _INIT_METHODS[WarmStart.name] = WarmStart
+
+
+class CmaEs(_SearchStart):
+    """Search for a start point with CMA-ES, over the whole box."""
+
+    name = "cmaes"
+    # objective evaluations, not candidates. A global search needs more of
+    # them than the local warm start: it spends the first generations on
+    # where the good region is, not on the value inside it.
+    default_iterations = 500
+
+    def skips_search(self, optimizer: dict[str, Any]) -> bool:
+        """Whether the training repeats this search, so it can be dropped."""
+        # `optimizer="cmaes"` runs this search again, from the point that
+        # this search returns. The second run starts with a new covariance
+        # matrix, so it drops what the first one learned. One run over the
+        # whole budget is then better, and the box gives it its start point
+        # and its step size.
+        return bool(optimizer["optimizer"] == el.cmaes.CMAES)
+
+    def search(  # noqa: PLR0913
+        self,
+        expert_elicited_statistics: dict[str, tf.Tensor],
+        parameters: list[Parameter],
+        trainer: Trainer,
+        model: dict[str, Any],
+        targets: list[Target],
+        expert: ExpertDict,
+        distribution: dict[str, Any],
+        max_evals: int,
+        seed: int,
+    ) -> dict[str, Any]:
+        """Return one value per hyperparameter, on the unconstrained scale."""
+        return el.cmaes.cma_search(
+            expert_elicited_statistics=expert_elicited_statistics,
+            parameters=parameters,
+            trainer=trainer,
+            model=model,
+            targets=targets,
+            expert=expert,
+            distribution=distribution,
+            max_evals=max_evals,
+            seed=seed,
+        )
+
+
+_INIT_METHODS[CmaEs.name] = CmaEs
 
 
 def uniform_samples(  # noqa: PLR0913, PLR0912, PLR0915

--- a/src/elicito/plots.py
+++ b/src/elicito/plots.py
@@ -9,7 +9,9 @@ from typing import TYPE_CHECKING, Any, cast
 import numpy as np
 import tensorflow as tf
 
+from elicito.cmaes import CMAES
 from elicito.exceptions import MissingOptionalDependencyError
+from elicito.initialization import hyper_names
 
 if TYPE_CHECKING:
     import matplotlib.axes
@@ -133,6 +135,16 @@ def initialization(
 
     """
     eliobj_res, *_ = _check_parallel(eliobj)
+
+    # check that all information can be assessed
+    if "initialization" not in eliobj_res.children:
+        msg = (
+            "No 'initialization' found in 'eliobj.results'. The initialization"
+            f" method '{eliobj.initializer['method']}' draws no candidates, so"
+            " there is no initialization distribution to plot."
+        )
+        raise KeyError(msg)
+
     # get number of hyperparameters and their names
     names, n_par, titles = _get_names_titles(
         eliobj_res.initialization.hyperparameter.values.tolist(), titles
@@ -144,12 +156,6 @@ def initialization(
     kwargs.setdefault("figsize", (cols * 2, rows * 2))
     kwargs.setdefault("constrained_layout", True)
     kwargs.setdefault("sharex", True)
-
-    # check that all information can be assessed
-    try:
-        eliobj_res.initialization
-    except KeyError:
-        logger.warning("Can't find 'initialization' in eliobj.results.")
 
     # plot ecdf of initialization distribution
     # differentiate between subplots that have (1) only one row vs.
@@ -321,9 +327,24 @@ def hyperparameter(
         )
 
     eliobj_res, parallel, n_reps = _check_parallel(eliobj)
-    # get number of hyperparameters and their names
+
+    # check that all information can be assessed
+    try:
+        history = eliobj_res.history_stats.hyperparameter
+    except AttributeError:
+        raise AttributeError(
+            "No information about 'hyperparameter' found in "
+            + "'eliobj.results.history_stats'."
+        )
+
+    # The names come from the model, in the order the initializer uses. They
+    # cannot come from the initialization group: an initializer that draws no
+    # candidates, such as `cmaes`, writes none. A shared hyperparameter is
+    # named once, and the gradients in the history are not hyperparameters.
+    recorded = list(history.data_vars)
     names, n_par, titles = _get_names_titles(
-        eliobj_res.initialization.hyperparameter.values.tolist(), titles
+        list(dict.fromkeys(n for n in hyper_names(eliobj.parameters) if n in recorded)),
+        titles,
     )
 
     # check chains that yield NaN
@@ -337,15 +358,6 @@ def hyperparameter(
     kwargs.setdefault("figsize", (cols * 2, rows * 2))
     kwargs.setdefault("constrained_layout", True)
     kwargs.setdefault("sharex", True)
-
-    # check that all information can be assessed
-    try:
-        eliobj_res.history_stats.hyperparameter
-    except AttributeError:
-        raise AttributeError(
-            "No information about 'hyperparameter' found in "
-            + "'eliobj.results.history_stats'."
-        )
 
     fig, axes = _setup_grid(rows, cols, k, **kwargs)
     for ax, hyp, title in zip(axes, names, titles):
@@ -520,7 +532,8 @@ def prior_joint(
             + " of parallelizations. 'idx' should not exceed"
             + f" {samples['prior'].sizes['replication']} but got {len(idx)}."
         )
-    if eliobj.results.history_stats.loss.sizes["epoch"] < eliobj.trainer["epochs"]:
+    recorded = eliobj.results.history_stats.loss.sizes["epoch"]
+    if recorded < _planned_epochs(eliobj, recorded):
         seed = eliobj.results.history_stats.seed_replication.sel(replication=idx).values
         raise ValueError(
             f"Training failed for seed {seed} (index={idx}). Loss is NAN."
@@ -1323,6 +1336,33 @@ def _convergence_plot(  # noqa: PLR0913
     return axes
 
 
+def _planned_epochs(eliobj: Any, recorded: int) -> int:
+    """
+    Count the history points that a finished run must have
+
+    The gradient fitter writes one point per epoch, so a shorter history means
+    that the run stopped early. The CMA-ES fitter writes one point per
+    generation, and the number of generations is not known before the run.
+
+    Parameters
+    ----------
+    eliobj
+        fitted ``eliobj`` object.
+
+    recorded
+        number of history points that this run wrote.
+
+    Returns
+    -------
+    :
+        expected number of history points.
+
+    """
+    if eliobj.optimizer["optimizer"] == CMAES:
+        return recorded
+    return int(eliobj.trainer["epochs"])
+
+
 def _check_NaN(eliobj: Any, n_reps: int) -> tuple[Any, ...]:
     # check whether some replications stopped with NAN
     ep_run = [
@@ -1330,12 +1370,17 @@ def _check_NaN(eliobj: Any, n_reps: int) -> tuple[Any, ...]:
         for i in range(n_reps)
     ]
     seed_rep = eliobj.results.history_stats.seed_replication.values
+
+    # a replication of a CMA-ES run that stopped early has fewer points than
+    # the other replications
+    n_planned = _planned_epochs(eliobj, max(ep_run))
+
     # extract successful and failed seeds and indices for further plotting
     fail = []
     success = []
     success_name = []
     for i, ep in enumerate(ep_run):
-        if ep < eliobj.trainer["epochs"]:
+        if ep < n_planned:
             fail.append((i, seed_rep[i]))
         else:
             success.append(i)

--- a/tests/unit/test_elicit.py
+++ b/tests/unit/test_elicit.py
@@ -174,7 +174,7 @@ def test_initializer():
     # the list of valid names comes from the initialization registry
     msg = (
         "Currently implemented initialization methods are "
-        "'lhs', 'random', 'sobol', 'warmstart', but got "
+        "'cmaes', 'lhs', 'random', 'sobol', 'warmstart', but got "
         "method='something' as input."
     )
     with pytest.raises(ValueError, match=msg):

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -859,3 +859,265 @@ def test_box_vector_reads_every_entry_of_the_box():
         radius=[1.0, 2.0], mean=[3.0, 4.0], hyper=["sigma0", "mu0"]
     )
     assert el.warmstart._box_vector(listed_box, names, "radius") == [2.0, 1.0]
+
+
+def test_cmaes_is_a_registered_initialization_method():
+    method = el.initialization.get_init_method("cmaes")
+
+    assert isinstance(method, el.initialization.CmaEs)
+    assert method.default_iterations == 500
+
+
+def test_cma_search_returns_one_value_per_hyperparameter():
+    pytest.importorskip("cma")
+
+    expert_elicits, _ = el.utils.get_expert_data(
+        base_eliobj.trainer,
+        base_eliobj.model,
+        base_eliobj.targets,
+        base_eliobj.expert,
+        base_eliobj.parameters,
+        base_eliobj.network,
+        base_eliobj.trainer["seed"],
+    )
+
+    hyperparams = el.cmaes.cma_search(
+        expert_elicited_statistics=expert_elicits,
+        parameters=base_eliobj.parameters,
+        trainer=base_eliobj.trainer,
+        model=base_eliobj.model,
+        targets=base_eliobj.targets,
+        expert=base_eliobj.expert,
+        distribution=el.initialization.uniform(radius=1.0, mean=0.0),
+        max_evals=12,
+        seed=0,
+    )
+
+    assert list(hyperparams) == el.initialization.hyper_names(base_eliobj.parameters)
+    assert all(np.isfinite(v) for v in hyperparams.values())
+
+
+def test_cma_search_falls_back_when_every_point_fails(monkeypatch, caplog):
+    """a point that failed is never returned as a start value"""
+    pytest.importorskip("cma")
+
+    monkeypatch.setattr(
+        el.warmstart,
+        "compile_score",
+        lambda **kwargs: lambda hyperparams: el.warmstart.PENALTY * 1.5,
+    )
+
+    with caplog.at_level("WARNING"):
+        hyperparams = el.cmaes.cma_search(
+            expert_elicited_statistics={},
+            parameters=base_eliobj.parameters,
+            trainer=base_eliobj.trainer,
+            model=base_eliobj.model,
+            targets=base_eliobj.targets,
+            expert=base_eliobj.expert,
+            distribution=el.initialization.uniform(radius=1.0, mean=2.0),
+            max_evals=12,
+            seed=0,
+        )
+
+    assert set(hyperparams.values()) == {2.0}
+    assert "every evaluated point failed" in caplog.text
+
+
+def _cmaes_eliobj(
+    epochs,
+    sigma0=0.5,
+    popsize=4,
+    method="parametric_prior",
+    init_method="sobol",
+):
+    """an eliobj that is fitted with the CMA-ES search instead of a gradient"""
+    return Elicit(
+        model=base_eliobj.model,
+        parameters=base_eliobj.parameters,
+        targets=base_eliobj.targets,
+        expert=base_eliobj.expert,
+        optimizer=el.optimizer(
+            optimizer=el.cmaes.CMAES, sigma0=sigma0, popsize=popsize
+        ),
+        trainer=el.trainer(method=method, seed=0, epochs=epochs, progress=0),
+        initializer=el.initializer(
+            method=init_method,
+            iterations=2,
+            distribution=el.initialization.uniform(radius=1.0, mean=0.0),
+        ),
+    )
+
+
+def test_cma_training_records_one_point_per_generation():
+    pytest.importorskip("cma")
+
+    eliobj = _cmaes_eliobj(epochs=12)
+    eliobj.fit()
+
+    loss = eliobj.results["history_stats/loss"]["total_loss"]
+    hyper = eliobj.results["history_stats/hyperparameter"]
+    # 12 evaluations, 4 candidates per generation
+    assert loss.sizes["epoch"] == 3
+    for name in el.initialization.hyper_names(base_eliobj.parameters):
+        assert hyper[name].sizes["epoch"] == 3
+    assert np.all(np.isfinite(loss.values))
+
+
+def test_cma_training_spends_the_budget(monkeypatch):
+    pytest.importorskip("cma")
+
+    calls = []
+    original = el.warmstart.evaluate
+
+    def counted(**kwargs):
+        calls.append(1)
+        return original(**kwargs)
+
+    monkeypatch.setattr(el.warmstart, "evaluate", counted)
+
+    eliobj = _cmaes_eliobj(epochs=12)
+    eliobj.fit()
+
+    # the budget, plus the final evaluation of the best point
+    assert len(calls) == 12 + 1
+
+
+def test_cma_training_improves_the_loss():
+    pytest.importorskip("cma")
+
+    eliobj = _cmaes_eliobj(epochs=40)
+    eliobj.fit()
+
+    loss = eliobj.results["history_stats/loss"]["total_loss"].values
+    assert loss[0, -1] < loss[0, 0]
+
+
+def test_step_size_reads_a_number():
+    assert el.cmaes._step_size(0.3, ["mu0", "sigma0"]) == (0.3, None)
+
+
+def test_step_size_orders_a_dict_like_the_variables():
+    names = ["mu0", "sigma0", "mu1"]
+    sigma0, stds = el.cmaes._step_size(dict(mu1=0.1, mu0=0.2), names)
+
+    # the scalar is 1.0, so `CMA_stds` alone sets the step size
+    assert sigma0 == 1.0
+    # `sigma0` is not given, so it gets the default
+    assert stds == [0.2, el.cmaes.DEFAULT_SIGMA0, 0.1]
+
+
+def test_step_size_fills_a_missing_name_from_the_default():
+    names = ["mu0", "sigma0", "mu1"]
+    box = dict(mu0=3.5, sigma0=3.5, mu1=3.5)
+
+    _, stds = el.cmaes._step_size(dict(mu1=0.1), names, box)
+
+    # `mu1` is given, the other two keep the value of the box
+    assert stds == [3.5, 3.5, 0.1]
+
+
+def test_step_size_rejects_an_unknown_hyperparameter():
+    with pytest.raises(ValueError, match="mu2"):
+        el.cmaes._step_size(dict(mu2=0.1), ["mu0", "sigma0"])
+
+
+def test_cma_training_accepts_a_step_size_per_hyperparameter():
+    pytest.importorskip("cma")
+
+    eliobj = _cmaes_eliobj(epochs=12, sigma0=dict(mu0=0.1, sigma2=1.0))
+    eliobj.fit()
+
+    loss = eliobj.results["history_stats/loss"]["total_loss"].values
+    assert np.all(np.isfinite(loss))
+    assert "sigma0=2 values" in repr(eliobj)
+
+
+def test_cmaes_init_drops_its_search_for_a_cmaes_training():
+    box = el.initialization.uniform(radius=1.0, mean=0.0)
+    method = el.initialization.resolve_init_method(
+        el.initializer(method="cmaes", distribution=box)
+    )
+
+    # the training runs the same search, so one search is enough
+    assert method.skips_search(dict(optimizer=el.cmaes.CMAES))
+    # a gradient training is a different search, so the start value is needed
+    assert not method.skips_search(dict(optimizer=tf.keras.optimizers.Adam))
+
+
+def test_warmstart_init_keeps_its_search_for_a_cmaes_training():
+    box = el.initialization.uniform(radius=1.0, mean=0.0)
+    method = el.initialization.resolve_init_method(
+        el.initializer(method="warmstart", distribution=box)
+    )
+
+    assert not method.skips_search(dict(optimizer=el.cmaes.CMAES))
+
+
+def test_box_step_size_reads_the_radius_of_the_box():
+    expert_elicits, _ = el.utils.get_expert_data(
+        base_eliobj.trainer,
+        base_eliobj.model,
+        base_eliobj.targets,
+        base_eliobj.expert,
+        base_eliobj.parameters,
+        base_eliobj.network,
+        base_eliobj.trainer["seed"],
+    )
+    box = el.initialization.uniform(radius=4.0, mean=0.0)
+
+    sigma0 = el.cmaes.box_step_size(
+        el.initializer(method="cmaes", distribution=box),
+        expert_elicits,
+        base_eliobj.parameters,
+    )
+
+    names = el.initialization.hyper_names(base_eliobj.parameters)
+    assert sigma0 == {name: 2.0 for name in names}
+
+    # a method that keeps its own search hands no box to the training
+    other = el.cmaes.box_step_size(
+        el.initializer(method="sobol", distribution=box),
+        expert_elicits,
+        base_eliobj.parameters,
+    )
+    assert other == el.cmaes.DEFAULT_SIGMA0
+
+
+def test_cma_training_runs_no_search_before_it(monkeypatch):
+    pytest.importorskip("cma")
+
+    calls = []
+    monkeypatch.setattr(el.cmaes, "cma_search", lambda **kwargs: calls.append(1) or {})
+
+    eliobj = _cmaes_eliobj(epochs=12, sigma0=None, init_method="cmaes")
+    eliobj.optimizer.pop("sigma0")
+    eliobj.fit()
+
+    assert calls == []
+    loss = eliobj.results["history_stats/loss"]["total_loss"].values
+    assert np.all(np.isfinite(loss))
+
+
+def test_cmaes_optimizer_rejects_the_deep_prior_method():
+    with pytest.raises(ValueError, match="parametric_prior"):
+        _cmaes_eliobj(epochs=12, method="deep_prior")
+
+
+def test_cmaes_optimizer_rejects_a_warmup():
+    eliobj = _cmaes_eliobj(epochs=12)
+    with pytest.raises(ValueError, match="warmup_epochs"):
+        Elicit(
+            model=eliobj.model,
+            parameters=eliobj.parameters,
+            targets=eliobj.targets,
+            expert=eliobj.expert,
+            optimizer=eliobj.optimizer,
+            trainer=eliobj.trainer,
+            initializer=el.initializer(
+                method="sobol",
+                iterations=2,
+                warmup_epochs=2,
+                distribution=el.initialization.uniform(radius=1.0, mean=0.0),
+            ),
+        )

--- a/tests/unit/test_plots.py
+++ b/tests/unit/test_plots.py
@@ -258,3 +258,71 @@ def test_prior_joint_panels_share_the_axis_of_their_column(fitted_eliobj):
     np.testing.assert_allclose(scatter.get_xdata(), priors[1], rtol=1e-6)
     np.testing.assert_allclose(scatter.get_ydata(), priors[0], rtol=1e-6)
     plt.close(fig)
+
+
+def test_plots_without_an_initialization_group():
+    """`initializer(method="cmaes")` draws no candidates, so it writes no group"""
+    pytest.importorskip("cma")
+    from tests.utils import eliobj as base
+
+    eliobj = el.Elicit(
+        model=base.model,
+        parameters=base.parameters,
+        targets=base.targets,
+        expert=base.expert,
+        optimizer=el.optimizer(optimizer=el.cmaes.CMAES, sigma0=0.5, popsize=4),
+        trainer=el.trainer(method="parametric_prior", seed=0, epochs=8, progress=0),
+        initializer=el.initializer(
+            method="cmaes",
+            distribution=el.initialization.uniform(radius=1.0, mean=0.0),
+        ),
+    )
+    eliobj.fit()
+    assert "initialization" not in eliobj.results.children
+
+    # the names come from the model, so the convergence plot still works
+    fig, axes = el.plots.hyperparameter(eliobj)
+    names = el.initialization.hyper_names(eliobj.parameters)
+    assert [ax.get_title() for ax in axes] == names
+    plt.close(fig)
+
+    # the ecdf of the initialization distribution has nothing to show
+    with pytest.raises(KeyError, match="draws no candidates"):
+        el.plots.initialization(eliobj)
+
+
+def test_hyperparameter_plot_leaves_out_the_gradients(fitted_eliobj):
+    """the history holds a gradient per hyperparameter; they are not panels"""
+    recorded = list(fitted_eliobj.results.history_stats.hyperparameter.data_vars)
+    assert any(name.startswith("grad_") for name in recorded)
+
+    fig, axes = el.plots.hyperparameter(fitted_eliobj)
+    assert axes.shape == (len(el.initialization.hyper_names(fitted_eliobj.parameters)),)
+    plt.close(fig)
+
+
+def test_plots_accept_a_cmaes_fit():
+    """the plots read the epoch axis as generations, not as gradient steps"""
+    pytest.importorskip("cma")
+    from tests.utils import eliobj as base
+
+    eliobj = el.Elicit(
+        model=base.model,
+        parameters=base.parameters,
+        targets=base.targets,
+        expert=base.expert,
+        optimizer=el.optimizer(optimizer=el.cmaes.CMAES, sigma0=0.5, popsize=4),
+        trainer=el.trainer(method="parametric_prior", seed=0, epochs=12, progress=0),
+        initializer=el.initializer(
+            method="sobol",
+            iterations=2,
+            distribution=el.initialization.uniform(radius=1.0, mean=0.0),
+        ),
+    )
+    eliobj.fit()
+
+    # 12 evaluations of 4 candidates are 3 generations, not 12 epochs
+    el.plots.loss(eliobj)
+    el.plots.hyperparameter(eliobj)
+    el.plots.prior_joint(eliobj)
+    plt.close("all")

--- a/uv.lock
+++ b/uv.lock
@@ -343,6 +343,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cma"
+version = "4.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/ac/8c27720838e293898671f01b5c452236a0c74f4799a3f2d5fcccbbf50d71/cma-4.4.4.tar.gz", hash = "sha256:632bd654b5dce04c0eaa3166679d3e4773ce7a79eab7934e7f363c341b9a8170", size = 316645, upload-time = "2026-02-25T22:18:16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/d4/ec46cedab6a6145e21768baa8110db3e2e836a320d8499e4ef18bc894e61/cma-4.4.4-py3-none-any.whl", hash = "sha256:edb6d02eb2aac2d54650f16a8f0c70711ff17445957de7c9de92ff7fd4b7ef38", size = 328311, upload-time = "2026-02-25T22:18:09.602Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -580,9 +593,13 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+cma = [
+    { name = "cma" },
+]
 full = [
     { name = "arviz-stats", version = "0.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "arviz-stats", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "cma" },
     { name = "matplotlib" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -923,6 +940,8 @@ tests-min = [
 [package.metadata]
 requires-dist = [
     { name = "arviz-stats", marker = "extra == 'plots'", specifier = ">=0.6.0" },
+    { name = "cma", marker = "extra == 'cma'", specifier = ">=3.3.0" },
+    { name = "elicito", extras = ["cma"], marker = "extra == 'full'" },
     { name = "elicito", extras = ["plots"], marker = "extra == 'full'" },
     { name = "elicito", extras = ["scipy"], marker = "extra == 'full'" },
     { name = "joblib", specifier = ">=1.4.2" },
@@ -935,7 +954,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.38" },
     { name = "xarray", specifier = ">=2025.9.0" },
 ]
-provides-extras = ["plots", "scipy", "full"]
+provides-extras = ["plots", "scipy", "cma", "full"]
 
 [package.metadata.requires-dev]
 all-dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -940,7 +940,7 @@ tests-min = [
 [package.metadata]
 requires-dist = [
     { name = "arviz-stats", marker = "extra == 'plots'", specifier = ">=0.6.0" },
-    { name = "cma", marker = "extra == 'cma'", specifier = ">=3.3.0" },
+    { name = "cma", marker = "extra == 'cma'", specifier = ">=3.4.0" },
     { name = "elicito", extras = ["cma"], marker = "extra == 'full'" },
     { name = "elicito", extras = ["plots"], marker = "extra == 'full'" },
     { name = "elicito", extras = ["scipy"], marker = "extra == 'full'" },


### PR DESCRIPTION
## Description

CMA-ES enters at two points, from one module.

- `el.initializer(method="cmaes")` searches the whole box. The samplers and the Nelder-Mead warm start take the first basin they meet.
- `el.optimizer(optimizer="cmaes", sigma0=...)` replaces the gradient descent. `trainer(epochs=...)` is then the budget in simulations.

It reuses `compile_score` and `_box_vector` from #52. `WarmStart` splits into `_SearchStart` and a subclass. The protocol gains `skips_search`.

`cma` is a new optional dependency, in the `cma` and `full` extras.