### PR TITLE
Fix dead cross-references in changelog fragments

### DIFF
--- a/changelog/46.feature.md
+++ b/changelog/46.feature.md
@@ -1,4 +1,4 @@
-Added [`from_elicits`][elicito.initialization.from_elicits], which derives the
+Added `from_elicits`, which derives the
 initialization box from the expert-elicited statistics during `fit`. Pass it to
 `el.initializer(distribution=...)` instead of `uniform` to avoid guessing a
 `mean` and a `radius` that match the scale of the hyperparameters.
@@ -10,7 +10,7 @@ diverge. It costs one forward simulation per evaluation. It is meant for a box
 you do not trust: it rescues a badly placed box, and does not improve a
 well-placed one.
 
-[`initializer`][elicito.elicit.initializer] now defaults to a Nelder-Mead warm
+[`initializer`][elicito.initializers.spec.initializer] now defaults to a Nelder-Mead warm
 start on a box derived from the expert data, so `el.initializer()` needs no
 argument. `distribution` and `iterations` are optional for every method; an
 omitted `iterations` takes the default of the method, 100 objective

--- a/changelog/46.improvement.md
+++ b/changelog/46.improvement.md
@@ -1,4 +1,4 @@
-[`from_elicits`][elicito.initialization.from_elicits] now derives the box from
+`from_elicits` now derives the box from
 the role of a hyperparameter, not from its constraint alone. A shape, such as
 the Weibull concentration, has no relation to the scale of the elicited data,
 so its box covers the natural range 1 to 5. Any other lower-bounded
@@ -9,4 +9,4 @@ The initialization methods now share one interface. `InitMethod` in
 `elicito.initialization` declares `check`, `propose` and `dry_run_slice`, and a
 registry maps a method name to its class. Adding a method no longer means an
 edit in five places. The valid names in the error message of
-[`initializer`][elicito.elicit.initializer] now come from that registry.
+[`initializer`][elicito.initializers.spec.initializer] now come from that registry.


### PR DESCRIPTION
## Description

The strict docs build failed on main with 4 autorefs warnings. from_elicits was removed, so its link is now plain code. initializer moved to elicito.initializers.spec.
